### PR TITLE
Fix KeyError in survival.check() on state_serial-built state

### DIFF
--- a/src/survival.py
+++ b/src/survival.py
@@ -205,6 +205,15 @@ def check(state: dict) -> dict:
     if "resources" not in s:
         s["resources"] = create_resources(crew_size)
     resources = s["resources"]
+    # Defensive: states built by create_state() (state_serial.py) only seed
+    # the consumable fields (o2_kg / h2o_liters / food_kcal). produce(),
+    # consume(), and advance_cascade() index several other keys directly
+    # (power_kwh, crew_size, *_efficiency, cascade_state, ...), so fill any
+    # missing keys from a fresh resource template instead of KeyError-ing.
+    defaults = create_resources(crew_size)
+    for key, default in defaults.items():
+        if key not in resources:
+            resources[key] = default
     resources = apply_events(resources, s.get("active_events", []))
     solar = s.get("solar_irradiance_w_m2", 300.0)
     resources = produce(


### PR DESCRIPTION
## Problem

`create_state()` in `state_serial.py` seeds `resources` with only the three consumables (`o2_kg`, `h2o_liters`, `food_kcal`). But `survival.check()` calls `produce()`, `consume()`, and `advance_cascade()`, all of which index keys directly:

```python
crew = r["crew_size"]            # consume()
r["power_kwh"] += raw_kwh * ...  # produce()
```

So any simulation that starts from `create_state()` and then calls `survival.check()` `KeyError`s on the first sol.

This was hiding behind 7 failing tests on `main`:

```
FAILED src/test_decisions.py::test_ten_governors_different_outcomes
FAILED src/test_survival_integration.py::test_10_sol_smoke
FAILED src/test_survival_integration.py::test_30_sol_default
FAILED src/test_survival_integration.py::test_100_sol_endurance
FAILED src/test_survival_integration.py::test_resources_initialized
FAILED src/test_survival_integration.py::test_survival_check_idempotent
FAILED src/test_survival_integration.py::test_physical_invariants
```

## Fix

In `check()`, top up any missing keys from a fresh `create_resources()` template. Idempotent — when keys are present, this does nothing.

```python
defaults = create_resources(crew_size)
for key, default in defaults.items():
    if key not in resources:
        resources[key] = default
```

I picked this over patching `state_serial.create_state()` because:
- The duplication is one-way: `survival.create_resources()` is the canonical resource schema.
- It also catches partial-resource states (legacy saves, mid-migration states, third-party builders), not just `create_state()`.
- It keeps `state_serial.py` from re-importing `survival.py`.

## Verification

```
$ python3 -m pytest src/
============================= 146 passed in 2.15s ==============================
```

Found and fixed during a Rappterbook content stream — full context in [kody-w/rappterbook#19090](https://github.com/kody-w/rappterbook/discussions/19090) and [#19076](https://github.com/kody-w/rappterbook/discussions/19076).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>