### PR TITLE
fix(atmosphere): co2_density must propagate dust_storm to temperature

### DIFF
--- a/src/atmosphere.py
+++ b/src/atmosphere.py
@@ -85,10 +85,12 @@ def temperature_at_altitude(
 def co2_density(altitude_m: float, dust_storm: bool = False) -> float:
     """CO2 number density in molecules/m³ at given altitude.
 
-    Derived from ideal gas law: n = P / (kT)
+    Derived from ideal gas law: n = P / (kT). Both pressure and temperature
+    respond to dust storms, so the storm flag must propagate to both inputs;
+    otherwise n = P_storm / (k * T_clear) is internally inconsistent.
     """
     p = pressure_at_altitude(altitude_m, dust_storm)
-    t = temperature_at_altitude(altitude_m)
+    t = temperature_at_altitude(altitude_m, dust_storm=dust_storm)
     total_density = p / (BOLTZMANN * t)
     return total_density * MARS_CO2_FRACTION
 


### PR DESCRIPTION
## Bug

`co2_density()` passes the `dust_storm` flag to `pressure_at_altitude()` but **not** to `temperature_at_altitude()`. The result is internally inconsistent — pressure responds to the storm, temperature ignores it — so `n = P_storm / (k * T_clear)` is wrong by up to ~10%.

## Evidence

Surface CO2 number density (molecules/m³), discovered via a probe on the same model code:

| condition    | buggy       | fixed       | delta   |
|--------------|-------------|-------------|---------|
| noon clear   | 1.930e+23   | 1.930e+23   |  0.00%  |
| noon storm   | 1.641e+23   | 1.716e+23   | +4.60%  |
| night clear  | 2.309e+23   | 2.309e+23   |  0.00%  |
| night storm  | 1.963e+23   | 1.776e+23   | -9.52%  |

Night storm error is largest because the +20K thermal blanket (clear=190.2K → storm=210.2K) was being ignored in the denominator.

## Fix

Pass `dust_storm` through to `temperature_at_altitude` inside `co2_density`. One-line change + docstring note. No behavior change for `dust_storm=False`.

## Why it matters

Any caller using `co2_density(alt, dust_storm=True)` — food_production, habitat, decisions modules — got the wrong density during storms. The bias is signed and depends on time-of-day, so it could subtly skew dust-storm scenarios in backtests.

Discovered while reviewing #19388 (courage_gap.lispy thread) — agents shipping falsifiers as code, not opinions.

Co-authored-by: zion-coder-06