### PR TITLE
fix(survival): backfill resource defaults in check() to prevent KeyError

### DIFF
--- a/src/survival.py
+++ b/src/survival.py
@@ -204,6 +204,14 @@ def check(state: dict) -> dict:
     crew_size = habitat.get("crew_size", 4)
     if "resources" not in s:
         s["resources"] = create_resources(crew_size)
+    else:
+        # Backfill missing required keys so partial resource dicts (e.g. from
+        # state_serial.create_state, which only seeds o2/h2o/food) don't crash
+        # produce()/consume() with KeyError: 'crew_size'.
+        defaults = create_resources(crew_size)
+        merged = dict(defaults)
+        merged.update(s["resources"])
+        s["resources"] = merged
     resources = s["resources"]
     resources = apply_events(resources, s.get("active_events", []))
     solar = s.get("solar_irradiance_w_m2", 300.0)


### PR DESCRIPTION
## What

`tests/test_decisions.py::test_ten_governors_different_outcomes` fails on `main` with:

```
src/survival.py:87: in produce
    crew = r["crew_size"]
KeyError: 'crew_size'
```

That is the only failing test on a fresh clone (1 failed, 82 passed). This PR fixes it.

## Why it broke

There are two ways resources can come into existence:

1. `survival.create_resources(crew_size)` — full dict with `crew_size`, `power_kwh`, `solar_efficiency`, `isru_efficiency`, `greenhouse_efficiency`, `cascade_state`, etc.
2. `state_serial.create_state(...)` — partial dict containing only `o2_kg`, `h2o_liters`, `food_kcal`.

`survival.check()` only invokes `create_resources` when `resources` is **missing entirely**. So when a state from `create_state` flows in, `check()` keeps the partial dict, hands it to `produce()`, and `produce()` immediately reads `r["crew_size"]` → KeyError.

The multi-governor test exercises exactly this path: it builds a state via `create_state`, then runs 10 governors through the survival loop.

## The fix

Merge the partial resources dict on top of `create_resources(crew_size)` defaults. Caller-provided values still win — we only fill in keys the caller did not set.

```python
if "resources" not in s:
    s["resources"] = create_resources(crew_size)
else:
    defaults = create_resources(crew_size)
    merged = dict(defaults)
    merged.update(s["resources"])
    s["resources"] = merged
```

## Verification

Before: `1 failed, 82 passed in 0.14s`
After:  `83 passed in 0.18s`

## Alternative considered

Patching `state_serial.create_state` to include all required resource keys would also work, but it duplicates the source of truth and means anyone building a state from scratch (e.g. legacy JSON load) has to know the full schema. Backfilling at the `check()` boundary keeps `create_resources` as the single owner of resource defaults.

---

Found while reviewing replay code from kody-w/rappterbook#19575 — wrote a verification harness, ran the test suite to compare two analyses, hit this crash on a clean checkout.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
